### PR TITLE
feat: add email subject handling and improve user filtering

### DIFF
--- a/src/main/java/br/com/pointer/pointer_back/repository/UsuarioRepository.java
+++ b/src/main/java/br/com/pointer/pointer_back/repository/UsuarioRepository.java
@@ -27,7 +27,8 @@ public interface UsuarioRepository extends JpaRepository<Usuario, Long>, JpaSpec
     @Query("SELECT u FROM Usuario u WHERE " +
            "(:tipoUsuario IS NULL OR u.tipoUsuario = :tipoUsuario) AND " +
            "(:setor IS NULL OR u.setor = :setor) AND " +
-           "(:status IS NULL OR u.status = :status)")
+           "(:status IS NULL OR u.status = :status) " +
+           "ORDER BY u.dataCriacao DESC")
     Page<Usuario> findByFilters(
         @Param("tipoUsuario") String tipoUsuario,
         @Param("setor") String setor,

--- a/src/main/java/br/com/pointer/pointer_back/service/EmailService.java
+++ b/src/main/java/br/com/pointer/pointer_back/service/EmailService.java
@@ -33,9 +33,10 @@ public class EmailService {
     public void sendPasswordEmail(String recipientEmail, String password, String name) {
         logger.info("Iniciando envio de email com senha para: {}", recipientEmail);
         String templateId = "d-d833e5b4a1e84774b566a29a2bd2e984";
+        String subject = "Sua senha de acesso - Pointer";
         Map<String, String> dynamicData = Map.of("senha", password, "nome", name);
 
-        Mail mail = createTemplateMail(recipientEmail, templateId, dynamicData);
+        Mail mail = createTemplateMail(recipientEmail, templateId, subject, dynamicData);
         sendMail(mail);
         logger.info("Email com senha enviado com sucesso para: {}", recipientEmail);
     }
@@ -43,13 +44,14 @@ public class EmailService {
     public void sendPrimeiroAcessoEmail(String recipientEmail, String name, String token) {
         logger.info("Iniciando envio de email de primeiro acesso para: {}", recipientEmail);
         String templateId = "d-d09158bb610d47f58c3a85e11bdee6ad";
+        String subject = "Pointer";
         String link = frontendUrl + "/primeiro-acesso?token=" + token;
         Map<String, String> dynamicData = Map.of("nome", name, "link", link);
 
         logger.info("Link de primeiro acesso gerado: {}", link);
         logger.info("Template ID: {}", templateId);
 
-        Mail mail = createTemplateMail(recipientEmail, templateId, dynamicData);
+        Mail mail = createTemplateMail(recipientEmail, templateId, subject, dynamicData);
         sendMail(mail);
         logger.info("Email de primeiro acesso enviado com sucesso para: {}", recipientEmail);
     }
@@ -57,9 +59,10 @@ public class EmailService {
     public void sendVerificationCodeEmail(String recipientEmail, String name) {
         logger.info("Iniciando envio de email com código de verificação para: {}", recipientEmail);
         String templateId = "d-8b3d5327466b48239ddc170d54af8bce";
+        String subject = "Código de verificação - Pointer";
         String code = generateRandomCode();
         Map<String, String> dynamicData = Map.of("codigo", code, "nome", name);
-        Mail mail = createTemplateMail(recipientEmail, templateId, dynamicData);
+        Mail mail = createTemplateMail(recipientEmail, templateId, subject, dynamicData);
         verificationCodes.put(recipientEmail, code);
         sendMail(mail);
         logger.info("Email com código de verificação enviado com sucesso para: {}", recipientEmail);
@@ -76,12 +79,13 @@ public class EmailService {
         logger.info("Código de verificação removido para: {}", email);
     }
 
-    private Mail createTemplateMail(String recipientEmail, String templateId, Map<String, String> dynamicData) {
+    private Mail createTemplateMail(String recipientEmail, String templateId, String subject, Map<String, String> dynamicData) {
         logger.debug("Criando email com template {} para: {}", templateId, recipientEmail);
         Email from = new Email("no-replypointer@bol.com.br");
         Email to = new Email(recipientEmail);
         Mail mail = new Mail();
         mail.setFrom(from);
+        mail.setSubject(subject);
         mail.setTemplateId(templateId);
 
         Personalization personalization = new Personalization();
@@ -89,7 +93,7 @@ public class EmailService {
         dynamicData.forEach(personalization::addDynamicTemplateData);
 
         mail.addPersonalization(personalization);
-        logger.debug("Email criado com dados dinâmicos: {}", dynamicData);
+        logger.debug("Email criado com assunto: {} e dados dinâmicos: {}", subject, dynamicData);
         return mail;
     }
 

--- a/src/main/java/br/com/pointer/pointer_back/service/UsuarioService.java
+++ b/src/main/java/br/com/pointer/pointer_back/service/UsuarioService.java
@@ -166,22 +166,6 @@ public class UsuarioService {
     @Transactional(readOnly = true)
     public ApiResponse<Page<UsuarioResponseDTO>> listarUsuarios(PageRequest pageRequest, String tipoUsuario,
             String setor, String status) {
-        Specification<Usuario> spec = Specification.where(null);
-
-        spec = spec.and((root, query, cb) -> {
-            assert query != null;
-            query.orderBy(cb.desc(root.get("dataCriacao")));
-            return null;
-        });
-
-        if (StringUtils.hasText(tipoUsuario)) {
-            spec = spec.and((root, query, cb) -> cb.equal(root.get("tipoUsuario"), tipoUsuario));
-        }
-
-        if (StringUtils.hasText(setor)) {
-            spec = spec.and((root, query, cb) -> cb.equal(root.get("setor"), setor));
-        }
-
         StatusUsuario statusUsuario = null;
         if (StringUtils.hasText(status)) {
             try {
@@ -400,7 +384,9 @@ public class UsuarioService {
         try {
             Usuario usuario = usuarioRepository.findByEmail(email)
                     .orElseThrow(() -> new UsuarioNaoEncontradoException(email));
-
+            if (usuario.getStatus().equals(StatusUsuario.INATIVO)) {
+                return ApiResponse.badRequest("Usuário inativo");
+            }
             emailService.sendVerificationCodeEmail(email, usuario.getNome());
             return ApiResponse.success("Código de verificação enviado com sucesso");
         } catch (UsuarioNaoEncontradoException e) {


### PR DESCRIPTION
- Include subject in email creation for password, verification code, and first access emails.
- Update dynamic email creation logic to set subject properly.
- Add sorting by creation date to `UsuarioRepository` user filtering.
- Remove redundant custom specifications in `UsuarioService` for improved performance and clarity.
- Add validation to prevent sending emails to inactive users.