### PR TITLE
feat: update allowed origins and adjust frontend container port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
     build: ../tcs-pointer-front
     container_name: pointer-front
     ports:
-      - "3000:80"
+      - "80:80"
     env_file:
       - .env
     restart: unless-stopped

--- a/src/main/java/br/com/pointer/pointer_back/constant/SecurityConstants.java
+++ b/src/main/java/br/com/pointer/pointer_back/constant/SecurityConstants.java
@@ -34,7 +34,9 @@ public final class SecurityConstants {
         "http://localhost:3000",
         "http://localhost:8080", 
         "http://127.0.0.1:3000",
-        "http://127.0.0.1:8080"
+        "http://127.0.0.1:8080",
+        "http://localhost:80",
+        "http://localhost"
     );
     
     public static final List<String> ALLOWED_METHODS = Arrays.asList(


### PR DESCRIPTION
- Add new entries (`http://localhost:80` and `http://localhost`) to allowed CORS origins in `SecurityConstants`.
- Update frontend container port mapping in `docker-compose.yml` to use `80:80`.