### PR TITLE
fix: correct sender and recipient validation in feedback and adjust f…

### DIFF
--- a/src/main/java/br/com/pointer/pointer_back/service/ComunicadoService.java
+++ b/src/main/java/br/com/pointer/pointer_back/service/ComunicadoService.java
@@ -61,8 +61,8 @@ public class ComunicadoService {
                     break;
                     
                 case "GESTOR":
-                    // GESTOR: Setor do usuário + apenasGestores = true
-                    comunicados = comunicadoRepository.findByFilters(usuario.getSetor(), titulo, true, pageRequest);
+                    // GESTOR: Setor do usuário + apenasGestores = null (retorna true e false)
+                    comunicados = comunicadoRepository.findByFilters(usuario.getSetor(), titulo, null, pageRequest);
                     break;
                     
                 default:

--- a/src/main/java/br/com/pointer/pointer_back/service/FeedbackService.java
+++ b/src/main/java/br/com/pointer/pointer_back/service/FeedbackService.java
@@ -39,7 +39,7 @@ public class FeedbackService {
     public ApiResponse<Void> criarFeedback(FeedbackDTO feedbackDTO) {
         try {
 
-            if (feedbackDTO.getKeycloakIdRemetente().equals(feedbackDTO.getKeycloakIdRemetente())) {
+            if (feedbackDTO.getKeycloakIdRemetente().equals(feedbackDTO.getIdUsuarioDestinatario())) {
                 return ApiResponse.badRequest("O remetente não pode ser o mesmo que o destinatário, favor selecionar outro usuário");
             }
 


### PR DESCRIPTION
…ilter logic for managers

- Fix validation in `FeedbackService` to compare sender (`KeycloakIdRemetente`) and recipient (`IdUsuarioDestinatario`).
- Update `ComunicadoService` to allow both true and false values for `apenasGestores` in `GESTOR` filter.